### PR TITLE
Set user photo from system

### DIFF
--- a/src/components/chat/index.vue
+++ b/src/components/chat/index.vue
@@ -23,6 +23,7 @@
           :is-expanded="isExpanded"
           :is-loading="!isLoaded"
           :user-context="userContext"
+          :user-data="userData"
           :channels="channels"
           :active-channel="activeChannel"
           :show-header="showHeader"
@@ -119,6 +120,10 @@ export default {
     user: {
       type: String,
       default: ""
+    },
+    userData: {
+      type: Object,
+      default: {}
     },
     branchId: {
         type: [String, Number],

--- a/src/components/chat/side.vue
+++ b/src/components/chat/side.vue
@@ -100,7 +100,13 @@ export default {
       type: Array,
       required: true,
     },
+    // twillio data
     userContext: {
+      type: Object,
+      required: true,
+    },
+    // engage data
+    userData: {
       type: Object,
       required: true,
     },
@@ -222,7 +228,7 @@ export default {
         return !this.search ? this.visibleChannels : fuse.search(this.search || "").map( item => item.item)
     },
     profileImage() {
-        return this.userContext.user.attributes ? this.userContext.user.attributes.photoUrl : "";
+        return this.userData.photo ? this.userData.photo.url : "";
     }
   },
   beforeDestroy() {
@@ -328,7 +334,7 @@ export default {
           if (this.channelData[channel.sid].lastMessage.author !== sender.identity) {
             unreadMessages = this.channelData[channel.sid].lastMessage.index - sender.lastConsumedMessageIndex || 0;
             this.$set(this.channelData[channel.sid], "unreadMessages", unreadMessages);
-            return unreadMessages;
+            return Math.abs(unreadMessages);
           }
       }
 


### PR DESCRIPTION
### Description
1. Pass user photo from engage to the chat widget.
2. Return absolute unread message.

### Why

1. We need to display the same user photo in engage and chat widget (or sidebar). 
Currently, the chat is updated every time a conversation with a lead is opened but the user photo could be different for every company causing a delay and showing the old picture until we reopen or change leads.

2.

### How
- Pass userData as a prop to the chat component.
